### PR TITLE
[CAF-35] Add module for aws_config_configuration_recorder

### DIFF
--- a/examples/config_configuration_recorders.tfvars
+++ b/examples/config_configuration_recorders.tfvars
@@ -1,0 +1,22 @@
+config_configuration_recorders = {
+  recorder_example = {
+    name         = "example-recorder"
+    role_arn_ref = "role_test"
+    recording_group = {
+      all_supported                 = true
+      include_global_resource_types = false
+      resource_types                = []
+    }
+  }
+}
+
+# pre-requisites
+iam_roles = {
+  role_test = {
+    name                     = "test-role"
+    description              = "Example IAM role"
+    assume_principals        = ["ec2.amazonaws.com"]
+    permissions_boundary_ref = "policy_boundary_test"
+    max_session_duration     = 3600
+  }
+}

--- a/src/_outputs.tf
+++ b/src/_outputs.tf
@@ -149,3 +149,7 @@ output "config_config_rules" {
 output "cloudwatch_metric_alarms" {
   value = module.cloudwatch_metric_alarms
 }
+
+output "config_configuration_recorders" {
+  value = module.config_configuration_recorders
+}

--- a/src/_variables.resources.tf
+++ b/src/_variables.resources.tf
@@ -71,3 +71,5 @@ variable "organizations_policies" { default = {} }
 variable "config_config_rules" { default = {} }
 
 variable "cloudwatch_metric_alarms" { default = {} }
+
+variable "config_configuration_recorders" { default = {} }

--- a/src/config_configuration_recorders.tf
+++ b/src/config_configuration_recorders.tf
@@ -1,0 +1,15 @@
+module "config_configuration_recorders" {
+  source   = "./modules/config_configuration_recorder"
+  for_each = var.config_configuration_recorders
+
+  settings        = each.value
+  global_settings = local.global_settings
+
+  resources = {
+    iam_roles = module.iam_roles
+  }
+
+  # client_config = {
+  #   landingzone_key = var.landingzone.key
+  # }
+}

--- a/src/modules/config_configuration_recorder/_locals.tf
+++ b/src/modules/config_configuration_recorder/_locals.tf
@@ -1,0 +1,11 @@
+locals {
+  role_arn = try(
+    var.resources.iam_roles[var.settings.role_arn_ref].arn,
+    var.settings.role_arn
+  )
+
+  tags = merge(
+    var.global_settings.tags,
+    try(var.settings.tags, {})
+  )
+}

--- a/src/modules/config_configuration_recorder/_outputs.tf
+++ b/src/modules/config_configuration_recorder/_outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = aws_config_configuration_recorder.main.rule_id
+  value = aws_config_configuration_recorder.main.id
 }

--- a/src/modules/config_configuration_recorder/_outputs.tf
+++ b/src/modules/config_configuration_recorder/_outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = aws_config_configuration_recorder.main.rule_id
+}

--- a/src/modules/config_configuration_recorder/_variables.tf
+++ b/src/modules/config_configuration_recorder/_variables.tf
@@ -1,0 +1,18 @@
+variable "global_settings" {
+  description = "Global settings for cafini"
+}
+
+variable "settings" {
+  description = "All the configuration for this resource"
+}
+
+variable "resources" {
+  description = "All required resources"
+}
+
+# variable "client_config" {
+#   description = "Client config such as current landingzone key"
+#   type = object({
+#     landingzone_key = string
+#   })
+# }

--- a/src/modules/config_configuration_recorder/main.tf
+++ b/src/modules/config_configuration_recorder/main.tf
@@ -3,15 +3,6 @@ resource "aws_config_configuration_recorder" "main" {
   name     = try(var.settings.name, null)
   region   = try(var.settings.region, null)
 
-  dynamic "custom_policy_details" {
-    for_each = can(var.settings.source.custom_policy_details) ? [1] : []
-    content {
-      enable_debug_log_delivery = try(var.settings.source.custom_policy_details.enable_debug_log_delivery, null)
-      policy_runtime            = var.settings.source.custom_policy_details.event_source
-      policy_text               = var.settings.source.custom_policy_details.maximum_execution_frequency
-    }
-  }
-
   dynamic "recording_group" {
     for_each = can(var.settings.recording_group) ? [1] : []
 

--- a/src/modules/config_configuration_recorder/main.tf
+++ b/src/modules/config_configuration_recorder/main.tf
@@ -1,0 +1,54 @@
+resource "aws_config_configuration_recorder" "main" {
+  role_arn = local.role_arn
+  name     = try(var.settings.name, null)
+  region   = try(var.settings.region, null)
+
+  dynamic "custom_policy_details" {
+    for_each = can(var.settings.source.custom_policy_details) ? [1] : []
+    content {
+      enable_debug_log_delivery = try(var.settings.source.custom_policy_details.enable_debug_log_delivery, null)
+      policy_runtime            = var.settings.source.custom_policy_details.event_source
+      policy_text               = var.settings.source.custom_policy_details.maximum_execution_frequency
+    }
+  }
+
+  dynamic "recording_group" {
+    for_each = can(var.settings.recording_group) ? [1] : []
+
+    content {
+      all_supported                 = try(var.settings.recording_group.all_supported, null)
+      resource_types                = try(var.settings.recording_group.resource_types, null)
+      include_global_resource_types = try(var.settings.recording_group.include_global_resource_types, null)
+
+      dynamic "exclusion_by_resource_types" {
+        for_each = can(var.settings.recording_group.exclusion_by_resource_types) ? [1] : []
+        content {
+          resource_types = try(var.settings.recording_group.exclusion_by_resource_types.resource_types, null)
+        }
+      }
+      dynamic "recording_strategy" {
+        for_each = can(var.settings.recording_group.recording_strategy) ? [1] : []
+        content {
+          use_only = try(var.settings.recording_group.recording_strategy.use_only, null)
+        }
+      }
+    }
+  }
+
+  dynamic "recording_mode" {
+    for_each = can(var.settings.recording_mode) ? [1] : []
+
+    content {
+      recording_frequency = var.settings.recording_mode.recording_frequency
+
+      dynamic "recording_mode_override" {
+        for_each = try(var.settings.recording_mode.recording_mode_override, {})
+        content {
+          resource_types      = recording_mode_override.value.resource_types
+          recording_frequency = recording_mode_override.value.recording_frequency
+          description         = try(recording_mode_override.value.description, null)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
[CAF-35] Add module for aws_config_configuration_recorder

[CAF-35]: https://efellows.atlassian.net/browse/CAF-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ